### PR TITLE
MOC-5: For every Post on the User's Feed, display the first Comment

### DIFF
--- a/apps/mockingbird/jest.config.ts
+++ b/apps/mockingbird/jest.config.ts
@@ -8,4 +8,5 @@ export default {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/mockingbird',
+  passWithNoTests: true,
 };

--- a/apps/mockingbird/src/_components/Comment.tsx
+++ b/apps/mockingbird/src/_components/Comment.tsx
@@ -1,12 +1,20 @@
 import { getUser } from '@/_services/users';
 import { Post } from '@/_types/post';
 import { auth } from '@/app/auth';
+import Link from 'next/link';
 import { PostHeader } from './PostHeader';
+
 type Props = {
   post: Post;
+  originalPostId: string;
+  linkToDetails?: boolean;
 };
 
-export async function Comment({ post }: Props) {
+export async function Comment({
+  post,
+  originalPostId,
+  linkToDetails = false,
+}: Props) {
   const session = await auth();
   const poster = await getUser(post.posterId);
 
@@ -14,19 +22,35 @@ export async function Comment({ post }: Props) {
   const imageSrc = poster?.image ?? '/generic-user-icon.jpg';
   const showOptionsMenu = post.posterId === session?.user?.id;
 
+  const renderContent = () => (
+    <>
+      <PostHeader
+        name={userName}
+        image={imageSrc}
+        date={post.createdAt}
+        postId={post.id}
+        small
+        isComment
+        showOptionsMenu={showOptionsMenu}
+      ></PostHeader>
+      <div className="text-sm p-2 bg-transparent rounded-lg">
+        <div>{post.content}</div>
+      </div>
+    </>
+  );
+
   return (
-    <div className="card card-compact shadow-md">
-      <div className="card-body">
-        <PostHeader
-          name={userName}
-          image={imageSrc}
-          date={post.createdAt}
-          postId={post.id}
-          small
-          isComment
-          showOptionsMenu={showOptionsMenu}
-        ></PostHeader>
-        <div className="text-sm p-2 bg-base-100 rounded-lg">{post.content}</div>
+    <div className={`card card-compact bg-base-100 shadow-md`}>
+      <div
+        className={`card-body rounded-lg ${
+          linkToDetails && 'hover:bg-base-200'
+        }`}
+      >
+        {linkToDetails ? (
+          <Link href={`/post/${originalPostId}`}>{renderContent()}</Link>
+        ) : (
+          <div>{renderContent()}</div>
+        )}
       </div>
     </div>
   );

--- a/apps/mockingbird/src/_components/CommentList.tsx
+++ b/apps/mockingbird/src/_components/CommentList.tsx
@@ -4,8 +4,9 @@ import { useMemo } from 'react';
 
 type Props = {
   feed: Post[];
+  originalPostId: string;
 };
-export async function CommentList({ feed }: Props) {
+export async function CommentList({ feed, originalPostId }: Props) {
   const sortedFeed = useMemo(() => {
     return feed.sort(
       (a, b) =>
@@ -17,7 +18,7 @@ export async function CommentList({ feed }: Props) {
     <ul className="list-none max-w-2xl">
       {sortedFeed.map((post) => (
         <li className="m-2" key={post.id}>
-          <Comment post={post} />
+          <Comment post={post} originalPostId={originalPostId} />
         </li>
       ))}
     </ul>

--- a/apps/mockingbird/src/_components/FeedList.tsx
+++ b/apps/mockingbird/src/_components/FeedList.tsx
@@ -17,7 +17,7 @@ export async function FeedList({ feed }: Props) {
     <ul className="list-none max-w-2xl">
       {sortedFeed.map((post) => (
         <li className="m-2" key={post.id}>
-          <SummaryPost post={post} linkToDetails />
+          <SummaryPost post={post} linkToDetails showFirstComment />
         </li>
       ))}
     </ul>

--- a/apps/mockingbird/src/_components/PostHeader.tsx
+++ b/apps/mockingbird/src/_components/PostHeader.tsx
@@ -26,7 +26,7 @@ export function PostHeader({
     <div className="flex flex-row">
       <div className="flex flex-row flex-auto">
         <div className="avatar">
-          <div className={`${small ? 'h-6' : 'h-12'} rounded-full`}>
+          <div className={`${small ? 'h-8' : 'h-12'} rounded-full`}>
             <img src={image} alt="Profile Picture"></img>
           </div>
         </div>

--- a/apps/mockingbird/src/_components/SummaryPost.tsx
+++ b/apps/mockingbird/src/_components/SummaryPost.tsx
@@ -5,13 +5,20 @@ import { HandThumbDownIcon, HandThumbUpIcon } from '@heroicons/react/20/solid';
 import Link from 'next/link';
 import { CommentButton } from './CommentButton.client';
 import { PostHeader } from './PostHeader';
+import { Comment } from './Comment';
+import { getFirstCommentForPost } from '@/_services/post';
 
 type Props = {
   post: Post;
   linkToDetails?: boolean;
+  showFirstComment?: boolean;
 };
 
-export async function SummaryPost({ post, linkToDetails = false }: Props) {
+export async function SummaryPost({
+  post,
+  linkToDetails = false,
+  showFirstComment = false,
+}: Props) {
   const session = await auth();
   const poster = await getUser(post.posterId);
 
@@ -19,6 +26,8 @@ export async function SummaryPost({ post, linkToDetails = false }: Props) {
   const imageSrc = poster?.image ?? '/generic-user-icon.jpg';
 
   const showOptionsMenu = post.posterId === session?.user?.id;
+
+  const firstComment = await getFirstCommentForPost(post.id);
 
   return (
     <div className="card bg-base-100 shadow-xl">
@@ -56,6 +65,15 @@ export async function SummaryPost({ post, linkToDetails = false }: Props) {
           <CommentButton post={post}></CommentButton>
         </div>
       </div>
+      {showFirstComment && firstComment && (
+        <div className="card-body pt-0">
+          <Comment
+            linkToDetails
+            post={firstComment}
+            originalPostId={post.id}
+          ></Comment>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/mockingbird/src/_services/post.ts
+++ b/apps/mockingbird/src/_services/post.ts
@@ -36,15 +36,24 @@ export async function getPostWithId(postId: string) {
   }
 }
 
-export async function getCommentsForPost(postId: string) {
+export async function getCommentsForPost(postId: string, limit?: number) {
   try {
-    const response = await fetch(await apiUrlFor(`/posts/${postId}/comments`));
+    const response = await fetch(
+      await apiUrlFor(
+        `/posts/${postId}/comments${limit ? `?limt=${limit}` : ``}`
+      )
+    );
     const posts = (await response.json()) as Post[];
     return posts;
   } catch (error) {
     console.error(error);
     return undefined;
   }
+}
+
+export async function getFirstCommentForPost(postId: string) {
+  const comments = await getCommentsForPost(postId, 1);
+  return comments?.[0];
 }
 
 export async function commentOnPost(

--- a/apps/mockingbird/src/app/(routes)/page.tsx
+++ b/apps/mockingbird/src/app/(routes)/page.tsx
@@ -3,6 +3,7 @@ import { NewPost } from '@/_components/NewPost.client';
 import { getFeedForUser } from '@/_services/feed';
 import { Post } from '@/_types/post';
 import { auth } from '@/app/auth';
+import { Suspense } from 'react';
 
 export default async function AppPage() {
   const session = await auth();
@@ -14,7 +15,15 @@ export default async function AppPage() {
   return (
     <div className="flex flex-col flex-auto">
       <NewPost user={session?.user}></NewPost>
-      <FeedList feed={feed}></FeedList>
+      <Suspense
+        fallback={
+          <div className="text-secondary-content m-2 text-center">
+            Loading...
+          </div>
+        }
+      >
+        <FeedList feed={feed}></FeedList>
+      </Suspense>
     </div>
   );
 }

--- a/apps/mockingbird/src/app/(routes)/post/[postId]/page.tsx
+++ b/apps/mockingbird/src/app/(routes)/post/[postId]/page.tsx
@@ -2,6 +2,7 @@ import { CommentList } from '@/_components/CommentList';
 import { SummaryPost } from '@/_components/SummaryPost';
 import { getCommentsForPost, getPostWithId } from '@/_services/post';
 import { auth } from '@/app/auth';
+import { Suspense } from 'react';
 
 export default async function PostDetailPage({
   params,
@@ -26,7 +27,15 @@ export default async function PostDetailPage({
   return (
     <div className="flex flex-col flex-auto bg-base-200">
       <SummaryPost post={post}></SummaryPost>
-      <CommentList feed={comments}></CommentList>
+      <Suspense
+        fallback={
+          <div className="text-secondary-content m-2 text-center">
+            Loading...
+          </div>
+        }
+      >
+        <CommentList feed={comments} originalPostId={postId}></CommentList>
+      </Suspense>
     </div>
   );
 }

--- a/apps/mockingbird/src/app/api/posts/[postId]/comments/route.ts
+++ b/apps/mockingbird/src/app/api/posts/[postId]/comments/route.ts
@@ -20,15 +20,20 @@ const paramsSchema = z.object({
 /**
  * Get all Comments on a Post
  */
-export const GET = auth(async function GET(request, context) {
+export const GET = auth(async function GET({ url: _url, auth }, context) {
   try {
-    validateAuthentication(request.auth);
+    validateAuthentication(auth);
 
     const { postId } = paramsSchema.parse(context.params);
+    const url = new URL(_url);
+    const _limit = url.searchParams.get('limit');
+    const limit = _limit ? parseInt(_limit) : undefined;
 
-    logger.info(`Getting comments for Post: { postId: ${postId} }`);
+    logger.info(
+      `Getting comments for Post: { postId: ${postId}, limit: ${limit} }`
+    );
 
-    const feed = await getCommentsForPost(postId);
+    const feed = await getCommentsForPost(postId, limit);
 
     return NextResponse.json(feed, { status: 200 });
   } catch (error) {

--- a/apps/mockingbird/src/app/api/posts/service.ts
+++ b/apps/mockingbird/src/app/api/posts/service.ts
@@ -24,7 +24,7 @@ export async function doesPostExist(postId: string) {
   return !!post;
 }
 
-export async function getCommentsForPost(postId: string) {
+export async function getCommentsForPost(postId: string, limit?: number) {
   const posts = await prisma.post.findMany({
     where: {
       responseToPostId: postId,
@@ -32,6 +32,7 @@ export async function getCommentsForPost(postId: string) {
     orderBy: {
       createdAt: 'desc',
     },
+    take: limit,
   });
 
   return posts;

--- a/design/api/v1/posts/[postId]/comments/GET comments for a Post.bru
+++ b/design/api/v1/posts/[postId]/comments/GET comments for a Post.bru
@@ -5,9 +5,13 @@ meta {
 }
 
 get {
-  url: {{apiHost}}/posts/:postId/comments
+  url: {{apiHost}}/posts/:postId/comments?limit=1
   body: none
   auth: none
+}
+
+params:query {
+  limit: 1
 }
 
 params:path {

--- a/stoyponents/jest.config.ts
+++ b/stoyponents/jest.config.ts
@@ -8,4 +8,5 @@ export default {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../coverage/stoyponents',
+  passWithNoTests: true,
 };


### PR DESCRIPTION
- display the first comment for a Post on the main Feed.
- clicking the comment will navigate to the Post page with that comment.
 - added `limit` query param to `/posts/:postId/comments` to set a limit to the number of comments returned.
 - added Suspense elements around loading Feeds.