### PR TITLE
MOC-51: Display number of comments on a post

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected -t lint test build
+      - run: npx nx affected -t lint test build --base=develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected -t lint test build --base=develop
+      - run: npx nx affected -t lint test

--- a/apps/mockingbird/src/_apiServices/fetchFromServer.ts
+++ b/apps/mockingbird/src/_apiServices/fetchFromServer.ts
@@ -1,6 +1,5 @@
 'use client';
 import { ResponseError } from '@/app/api/errors';
-import { baseUrlForApi } from './apiUrlFor';
 
 let baseApiUrl: Promise<string>;
 

--- a/apps/mockingbird/src/_components/PostActionsFooter.tsx
+++ b/apps/mockingbird/src/_components/PostActionsFooter.tsx
@@ -8,7 +8,9 @@ interface Props {
 
 export function PostActionsFooter({ post, ...rest }: Props) {
   return (
-    <div className={`flex flex-row flex-auto gap-1 m-2`}>
+    <div
+      className={`flex flex-row flex-auto gap-1 m-2 pt-2 border-t-[1px] border-solid border-neutral-content`}
+    >
       <div className="flex flex-row flex-auto justify-end">
         <CommentButton post={post}></CommentButton>
       </div>

--- a/apps/mockingbird/src/_components/ReplyFooter.client.tsx
+++ b/apps/mockingbird/src/_components/ReplyFooter.client.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export function ReplyFooter({ onReplyToComment }: Props) {
   return (
-    <div className="flex flex-row flex-auto justify-end">
+    <div className="flex flex-row flex-auto justify-end ml-2 pt-2 border-t-[1px] border-solid border-neutral-content">
       <button className="btn btn-xs" onClick={onReplyToComment}>
         <ChatBubbleLeftEllipsisIcon className="h-4 w-4" />
         Reply

--- a/apps/mockingbird/src/_components/SummaryPost.tsx
+++ b/apps/mockingbird/src/_components/SummaryPost.tsx
@@ -1,4 +1,7 @@
-import { getCommentsForPost } from '@/_server/postsService';
+import {
+  getCommentsForPost,
+  getNumberOfCommentsForPost,
+} from '@/_server/postsService';
 import { getUserById } from '@/_server/usersService';
 import { Post } from '@/_types/post';
 import { auth } from '@/app/auth';
@@ -33,6 +36,8 @@ export async function SummaryPost({
   const comments =
     (await getCommentsForPost(post.id, showFirstComment ? 1 : undefined)) ?? [];
 
+  const numberOfComments = await getNumberOfCommentsForPost(post.id);
+
   return (
     <div className="card bg-base-100 shadow-xl">
       <div className="card-body">
@@ -57,6 +62,11 @@ export async function SummaryPost({
               <TextDisplay data={post.content}></TextDisplay>
             )}
           </div>
+          {numberOfComments > 0 && (
+            <div className="mr-2 text-xs text-end text-info-content">
+              {numberOfComments} Comment{numberOfComments === 1 ? '' : 's'}
+            </div>
+          )}
           <PostActionsFooter post={post}></PostActionsFooter>
         </div>
         <div className="card-actions"></div>

--- a/apps/mockingbird/src/_server/postsService.ts
+++ b/apps/mockingbird/src/_server/postsService.ts
@@ -59,6 +59,17 @@ export async function getCommentsForPost(postId: PostId, limit?: number) {
   return comments;
 }
 
+export async function getNumberOfCommentsForPost(postId: PostId) {
+  const rawData = await prisma.post.count({
+    where: {
+      responseToPostId: postId,
+    },
+  });
+
+  const numberOfComments = z.number().parse(rawData);
+  return numberOfComments;
+}
+
 export async function deletePost(postId: PostId) {
   const result = await prisma.$transaction([
     // delete comments to this Post


### PR DESCRIPTION
 - add function `getNumberOfCommentsForPost` to `postsServices`
 - add dividing bar between Post/Comment text and Comment/Reply buttons
 - display the number of top-level Comments on a Post above the Comment button.  Only displays if there are any comments.