### PR TITLE
MOC-62-Support-adding-external-image-link-to-a-Post

### DIFF
--- a/apps/mockingbird-e2e/src/posts.spec.ts
+++ b/apps/mockingbird-e2e/src/posts.spec.ts
@@ -12,7 +12,7 @@ const getCreatePostButton = (page: Page) =>
   page.getByRole('button', { name: "What's going on" });
 
 const testPostContent = 'TEST Post 1';
-const testCommentContnet = 'TEST Comment 1';
+const testCommentContent = 'TEST Comment 1';
 const testReplyContent = 'TEST Reply 1';
 
 test.describe('Creating and commenting on posts', () => {
@@ -63,20 +63,37 @@ test.describe('Creating and commenting on posts', () => {
     await post.getByRole('button', { name: 'Comment' }).click();
 
     const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
     await expect(dialog.getByText(testPostContent)).toBeVisible();
 
     const editor = getPostEditor(dialog);
-    await editor.fill(testCommentContnet);
-    await dialog.getByRole('button', { name: 'Post' }).click();
+    await editor.fill(testCommentContent);
+    const postButton = dialog.getByRole('button', { name: 'Post' });
+    await expect(postButton).toBeVisible();
+    await postButton.click();
+
+    await expect(dialog).toBeHidden();
+    await expect(posts).toHaveCount(2);
+
+    // ensure the comment has all the expected content
+    const comment = posts.last();
+    await expect(comment).toBeVisible();
+    await expect(comment.getByText(testUserName)).toBeVisible();
+    await expect(comment.getByText(testCommentContent)).toBeVisible();
+    await expect(
+      comment.getByRole('button', { name: 'Options' })
+    ).toBeVisible();
+    await expect(comment.getByRole('button', { name: 'Reply' })).toBeVisible();
   });
 
   test('reply to comment', async ({ page }) => {
     await performSignIn(page);
 
     const posts = page.getByRole('listitem');
-    await expect(posts).toHaveCount(2);
+    // await expect(posts).toHaveCount(2);
 
     const replyButton = page.getByRole('button', { name: 'Reply' });
+    await expect(replyButton).toBeVisible();
     const editor = getPostEditor(page);
 
     await replyButton.click();
@@ -84,14 +101,18 @@ test.describe('Creating and commenting on posts', () => {
     await editor.fill(testReplyContent);
     await expect(editor).toHaveText(testReplyContent);
     await page.getByRole('button', { name: 'Cancel' }).click();
-    await expect(editor).not.toBeVisible();
+    await expect(editor).toBeHidden();
     await expect(posts).toHaveCount(2);
 
     await replyButton.click();
     await editor.fill(testReplyContent);
     await expect(editor).toHaveText(testReplyContent);
-    await page.getByRole('button', { name: 'Post' }).click();
-    await expect(editor).not.toBeVisible();
+
+    const postButton = page.getByRole('button', { name: 'Post' });
+    await expect(postButton).toBeVisible();
+    await postButton.click();
+
+    await expect(editor).toBeHidden();
     await expect(posts).toHaveCount(2);
   });
 

--- a/apps/mockingbird/env.ts
+++ b/apps/mockingbird/env.ts
@@ -43,6 +43,7 @@ export const env = createEnv({
     CLOUDFLARE_R2_BUCKET_NAME: z.string().min(1),
 
     IMAGES_BASE_URL: z.string().url(),
+    IMAGES_MAX_SIZE_IN_BYTES: z.string(),
   },
 
   /**

--- a/apps/mockingbird/src/_apiServices/images.ts
+++ b/apps/mockingbird/src/_apiServices/images.ts
@@ -45,6 +45,35 @@ export async function uploadImage(
   return newImage;
 }
 
+export async function addExternalImage(
+  userId: UserId,
+  imageUrl: string,
+  metadata?: {
+    description?: string;
+    albumId?: AlbumId;
+  }
+): Promise<Image> {
+  const formData = new FormData();
+  formData.append('imageUrl', imageUrl);
+  formData.append('description', metadata?.description || '');
+  formData.append('albumId', metadata?.albumId || '');
+
+  const response = await fetchFromServer(`/users/${userId}/images`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    console.error(
+      `Failed to upload image: ${response.status}: ${response.statusText}`
+    );
+  }
+
+  const rawData = await response.json();
+  const newImage = ImageSchema.parse(rawData);
+  return newImage;
+}
+
 /**
  * Fetches an image by its ID from the server.
  *

--- a/apps/mockingbird/src/_components/CommentButton.client.tsx
+++ b/apps/mockingbird/src/_components/CommentButton.client.tsx
@@ -6,7 +6,7 @@ import { Post } from '@/_types/post';
 import { ChatBubbleLeftEllipsisIcon } from '@heroicons/react/20/solid';
 import { useRouter } from 'next/navigation';
 import { useDialogManager } from './DialogManager.client';
-import { SubmitPostParams } from './PostEditorDialog.client';
+import { SubmitPostParams } from './postEditor/PostEditorDialog.client';
 
 type Props = {
   post: Post;

--- a/apps/mockingbird/src/_components/DialogManager.client.tsx
+++ b/apps/mockingbird/src/_components/DialogManager.client.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
-import { PostEditorDialog } from './PostEditorDialog.client';
+import { PostEditorDialog } from './postEditor/PostEditorDialog.client';
 import { SelectImageDialog } from './SelectImageDialog.client';
 
 type PostEditorOptions = Omit<

--- a/apps/mockingbird/src/_components/ImageDisplay.client.tsx
+++ b/apps/mockingbird/src/_components/ImageDisplay.client.tsx
@@ -38,13 +38,13 @@ export function ImageDisplay({ imageId }: Props) {
         <img
           src={MISSING_IMAGE_URL}
           alt="Missing Image"
-          className="max-w-[50%] m-auto"
+          className="max-w-[50%] max-h-96 m-auto"
         />
       ) : image ? (
         <img
           src={image.imageUrl}
           alt={image.description}
-          className="max-w-[50%] m-auto"
+          className="max-w-[50%] max-h-96 m-auto"
           onError={(event) => {
             event.currentTarget.onerror = null;
             setMissingImage(true);

--- a/apps/mockingbird/src/_components/NewPost.client.tsx
+++ b/apps/mockingbird/src/_components/NewPost.client.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 import { useDialogManager } from './DialogManager.client';
-import { type SubmitPostParams } from './PostEditorDialog.client';
+import { type SubmitPostParams } from './postEditor/PostEditorDialog.client';
 
 type Props = {
   user: SessionUser | undefined;

--- a/apps/mockingbird/src/_components/postEditor/AddImageUrl.client.tsx
+++ b/apps/mockingbird/src/_components/postEditor/AddImageUrl.client.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable @next/next/no-img-element */
+'use client';
+import { addExternalImage } from '@/_apiServices/images';
+import { useSessionUser } from '@/_hooks/useSessionUser';
+import { type ImageId } from '@/_types/images';
+import { TrashIcon } from '@heroicons/react/20/solid';
+import { useCallback, useMemo, useState } from 'react';
+
+interface Props {
+  onImageSelected: (imageId: ImageId | undefined) => void;
+}
+
+export function AddImageUrl({ onImageSelected }: Props) {
+  const user = useSessionUser();
+
+  const [imageUrl, setImageUrl] = useState<string>('');
+
+  const validImageUrl = useMemo(() => {
+    try {
+      new URL(imageUrl);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }, [imageUrl]);
+
+  const handleAddImageUrl = useCallback(
+    async (imageUrl: string | undefined) => {
+      if (!imageUrl || !user?.id) {
+        return;
+      }
+      try {
+        const { id } = await addExternalImage(user.id, imageUrl, {
+          description: 'External image',
+        });
+        onImageSelected(id);
+      } catch (error) {
+        console.error(error);
+      }
+    },
+    [user?.id, onImageSelected]
+  );
+
+  return (
+    <div className="card flex flex-col h-full">
+      <div className="card-title mx-4 mt-4">Add Image URL</div>
+      <div className="card-body">
+        <div className="join">
+          <input
+            type="text"
+            placeholder="Image URL"
+            className="input input-bordered w-full join-item"
+            value={imageUrl}
+            onChange={(e) => setImageUrl(e.target.value)}
+          ></input>
+          <button
+            className="btn join-item"
+            onClick={() => setImageUrl('')}
+            title="Clear"
+          >
+            <TrashIcon className="w-4 h-4" />
+          </button>
+        </div>
+        <div>
+          {validImageUrl && (
+            <img
+              src={imageUrl}
+              alt="Image"
+              className="w-full max-h-96 object-contain"
+            />
+          )}
+        </div>
+      </div>
+      <div className="card-actions m-1 justify-end">
+        <button
+          className="btn btn-secondary btn-outline"
+          onClick={() => onImageSelected(undefined)}
+        >
+          Cancel
+        </button>
+        <button
+          className="btn btn-primary btn-outline"
+          onClick={() => handleAddImageUrl(imageUrl)}
+        >
+          Select Image
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mockingbird/src/_components/postEditor/AddToPostOptions.client.tsx
+++ b/apps/mockingbird/src/_components/postEditor/AddToPostOptions.client.tsx
@@ -1,16 +1,22 @@
 'use client';
-import { PhotoIcon, SquaresPlusIcon } from '@heroicons/react/24/solid';
+import {
+  GlobeAltIcon,
+  PhotoIcon,
+  SquaresPlusIcon,
+} from '@heroicons/react/24/solid';
 import { FileSelectButton } from '@mockingbird/stoyponents';
 
 interface Props {
   disableImageSelection?: boolean;
   onImageSelected: (file: File) => void;
   onPickImage: () => void;
+  onAddImageURL: () => void;
 }
 
 export function AddToPostOptions({
   onImageSelected,
   onPickImage,
+  onAddImageURL,
   disableImageSelection,
 }: Props) {
   return (
@@ -32,6 +38,15 @@ export function AddToPostOptions({
       >
         <span className="w-6 h-6 tooltip" data-tip="Select Image">
           <SquaresPlusIcon></SquaresPlusIcon>
+        </span>
+      </button>
+      <button
+        className="join-item btn btn-ghost btn-primary"
+        disabled={disableImageSelection}
+        onClick={() => onAddImageURL()}
+      >
+        <span className="w-6 h-6 tooltip" data-tip="Add External Image">
+          <GlobeAltIcon></GlobeAltIcon>
         </span>
       </button>
     </div>

--- a/apps/mockingbird/src/_components/postEditor/PostEditorDialog.client.tsx
+++ b/apps/mockingbird/src/_components/postEditor/PostEditorDialog.client.tsx
@@ -13,9 +13,10 @@ import {
   TextEditor,
 } from '@mockingbird/stoyponents';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { ImageView } from '../ImageView.client';
+import { PostView } from '../PostView';
+import { AddImageUrl } from './AddImageUrl.client';
 import { AddToPostOptions } from './AddToPostOptions.client';
-import { ImageView } from './ImageView.client';
-import { PostView } from './PostView';
 import { SelectExistingImage } from './SelectExistingImage.client';
 
 type Props = {
@@ -32,6 +33,12 @@ type Props = {
 
 export type SubmitPostParams = Parameters<Props['onSubmitPost']>[0];
 
+enum EditorMode {
+  EDITING,
+  SELECT_IMAGE,
+  ADD_IMAGE_URL,
+}
+
 export function PostEditorDialog({
   onSubmitPost,
   onClosed,
@@ -47,7 +54,7 @@ export function PostEditorDialog({
   const [imageUrl, setImageUrl] = useState<string>();
   const [imageId, setImageId] = useState<ImageId>();
 
-  const [isPickingImage, setIsPickingImage] = useState(false);
+  const [editorMode, setEditorMode] = useState<EditorMode>(EditorMode.EDITING);
 
   const [posterInfo, setPosterInfo] = useState<{
     userName: string;
@@ -129,7 +136,7 @@ export function PostEditorDialog({
         setImageFile(undefined);
         setImageUrl(undefined);
       }
-      setIsPickingImage(false);
+      setEditorMode(EditorMode.EDITING);
     },
     [setImageFile, setImageUrl]
   );
@@ -147,10 +154,14 @@ export function PostEditorDialog({
           onClosed={onClosed}
         ></DialogHeader>
         <DialogBody>
-          {isPickingImage ? (
+          {editorMode === EditorMode.SELECT_IMAGE ? (
             <SelectExistingImage
               onImageSelected={handleExistingImageSelected}
             ></SelectExistingImage>
+          ) : editorMode === EditorMode.ADD_IMAGE_URL ? (
+            <AddImageUrl
+              onImageSelected={handleExistingImageSelected}
+            ></AddImageUrl>
           ) : (
             <div className="h-full flex flex-col">
               <div className="h-[1px] flex flex-col flex-auto overflow-scroll">
@@ -170,7 +181,8 @@ export function PostEditorDialog({
               </div>
               <AddToPostOptions
                 onImageSelected={handleImageSelected}
-                onPickImage={() => setIsPickingImage(true)}
+                onPickImage={() => setEditorMode(EditorMode.SELECT_IMAGE)}
+                onAddImageURL={() => setEditorMode(EditorMode.ADD_IMAGE_URL)}
                 disableImageSelection={!!imageFile || !!imageId}
               ></AddToPostOptions>
             </div>

--- a/apps/mockingbird/src/_components/postEditor/SelectExistingImage.client.tsx
+++ b/apps/mockingbird/src/_components/postEditor/SelectExistingImage.client.tsx
@@ -39,7 +39,7 @@ export function SelectExistingImage({ onImageSelected }: Props) {
 
   return (
     <div className="card flex flex-col h-full">
-      <div className="card-title">Select existing image</div>
+      <div className="card-title mx-4 mt-4 mb-2">Select existing image</div>
       <div className="card-body flex-auto h-[1px] overflow-y-scroll">
         <div className="grid-cols-3 grid gap-2">
           {images.length > 0 ? (
@@ -66,7 +66,7 @@ export function SelectExistingImage({ onImageSelected }: Props) {
           )}
         </div>
       </div>
-      <div className="card-actions m-1">
+      <div className="card-actions m-1 mt-2 justify-end">
         <button
           className="btn btn-secondary btn-outline"
           onClick={() => onImageSelected(undefined)}


### PR DESCRIPTION
 - add option when creating/commenting on a Post to add an external image URL instead of uploading a custom image
 - update POST `api/users/[userId]/images` to take either an image File or a url to an image on the internet.
 - move post editor components into a common folder
 - update e2e tests
 - add max image upload size specified in env.MAX_IMAGE_SIZE, or 2mb by default.