### PR TITLE
MOC-63: Add CAPTCHA

### DIFF
--- a/apps/mockingbird/env.ts
+++ b/apps/mockingbird/env.ts
@@ -44,6 +44,9 @@ export const env = createEnv({
 
     IMAGES_BASE_URL: z.string().url(),
     IMAGES_MAX_SIZE_IN_BYTES: z.string(),
+
+    TURNSTILE_SITE_KEY: z.string().min(1),
+    TURNSTILE_SECRET_KEY: z.string().min(1),
   },
 
   /**

--- a/apps/mockingbird/src/_apiServices/fetchFromServer.ts
+++ b/apps/mockingbird/src/_apiServices/fetchFromServer.ts
@@ -29,6 +29,11 @@ export async function fetchFromServer(endpoint: string, options?: RequestInit) {
   };
   const response = await fetch(apiUrl, requestInit);
   if (!response.ok) {
+    const { message } = await response.json();
+    if (message) {
+      throw new ResponseError(response.status, message);
+    }
+
     throw new ResponseError(response.status, response.statusText);
   }
   return response;

--- a/apps/mockingbird/src/_server/turnstileService.ts
+++ b/apps/mockingbird/src/_server/turnstileService.ts
@@ -1,0 +1,44 @@
+import { env } from '@/../env';
+import baseLogger from './logger';
+
+const logger = baseLogger.child({
+  service: 'turnstile:service',
+});
+
+interface TurnstileResponse {
+  success: boolean;
+  'error-codes'?: string[];
+  challenge_ts?: string;
+  hostname?: string;
+}
+
+export async function verifyTurnstile(token: string) {
+  const secretKey = env.TURNSTILE_SECRET_KEY;
+
+  if (!secretKey) {
+    logger.error('TURNSTILE_SECRET_KEY is not set');
+    return false;
+  }
+
+  try {
+    const response = await fetch(
+      'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          secret: secretKey,
+          response: token,
+        }),
+      }
+    );
+
+    const data: TurnstileResponse = await response.json();
+    return data.success;
+  } catch (error) {
+    logger.error('Turnstile verification error:', error);
+    return false;
+  }
+}

--- a/apps/mockingbird/src/_types/createUser.ts
+++ b/apps/mockingbird/src/_types/createUser.ts
@@ -8,6 +8,7 @@ export const CreateUserDataSchema = z.object({
     .max(100, { message: 'Name is too long' }),
   email: z.string().email(),
   password: PasswordSchema,
+  turnstileToken: z.string().optional(),
 });
 export type CreateUserData = z.infer<typeof CreateUserDataSchema>;
 

--- a/apps/mockingbird/src/app/auth/create-account/_components/getTurnstileSiteKey.ts
+++ b/apps/mockingbird/src/app/auth/create-account/_components/getTurnstileSiteKey.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { env } from '@/../env';
+
+export async function getTurnstileSiteKey() {
+  if (env.NODE_ENV === 'development' || env.VERCEL_ENV === 'development') {
+    /** See https://developers.cloudflare.com/turnstile/troubleshooting/testing/ */
+    return '1x00000000000000000000AA'; // always pass
+    // return '2x00000000000000000000AA'; // always fail
+    // return `3x00000000000000000000FF`; // force challenge
+  }
+
+  return env.TURNSTILE_SITE_KEY;
+}

--- a/apps/mockingbird/src/app/layout.tsx
+++ b/apps/mockingbird/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
       <body className="h-screen bg-neutral">
         <ErrorBoundary fallbackRender={renderError}>
           <SessionProvider session={session}>
-            <div className="w-full h-full bg-neutral">
+            <div className="w-full h-auto bg-neutral">
               <Suspense
                 fallback={
                   <span className="loading loading-ball loading-lg"></span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-s3": "^3.735.0",
         "@heroicons/react": "^2.1.5",
         "@hookform/resolvers": "^3.9.0",
+        "@marsidev/react-turnstile": "^1.1.0",
         "@prisma/client": "^5.22.0",
         "@redux-devtools/extension": "^3.3.0",
         "@tailwindcss/typography": "^0.5.15",
@@ -4550,6 +4551,15 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.1.0.tgz",
+      "integrity": "sha512-X7bP9ZYutDd+E+klPYF+/BJHqEyyVkN4KKmZcNRr84zs3DcMoftlMAuoKqNSnqg0HE7NQ1844+TLFSJoztCdSA==",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
+      }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
       "version": "0.6.16",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@aws-sdk/client-s3": "^3.735.0",
     "@heroicons/react": "^2.1.5",
     "@hookform/resolvers": "^3.9.0",
+    "@marsidev/react-turnstile": "^1.1.0",
     "@prisma/client": "^5.22.0",
     "@redux-devtools/extension": "^3.3.0",
     "@tailwindcss/typography": "^0.5.15",


### PR DESCRIPTION
 - add `react-turnstile` to perform a Cloudflare Turnstile CAPTCHA-style verification when creating a new user account
 - updated `fetchFromServer` to return the error message from the server when a fetch fails. Before it was only returning the error code.
 - require providing a valid Turnstile token when creating a new user. The check is bypassed when running on localhost.
 - add server function `getTurnstileSiteKey` to return the site key to use for Turnstile verification widget.